### PR TITLE
Ant antlr update

### DIFF
--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -50,11 +50,11 @@
     </parent>
     <groupId>org.glassfish.external</groupId>
     <artifactId>ant</artifactId>
-    <version>1.8.4-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <name>Ant repackaged as an OSGI bundle</name>
 
     <properties>
-        <ant.version>1.8.3</ant.version>
+        <ant.version>1.10.1</ant.version>
         <release.arguments />
     </properties>
 
@@ -68,41 +68,15 @@
     </licenses>
 
     <scm>
-        <connection>scm:svn:https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/ant</connection>
-        <developerConnection>scm:svn:https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/ant</developerConnection>
-        <url>https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/ant</url>
+        <connection>scm:git:git@github.com:javaee/repackaged.git</connection>
+        <developerConnection>scm:git:git@github.com:javaee/repackaged.git</developerConnection>
+        <url>https://github.com/javaee/repackaged.git</url>
     </scm>
 
-    <mailingLists>
-        <mailingList>
-            <name>dev</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>dev@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/dev/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>users</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>users@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/users/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>issues</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>issues@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/issues/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>commits</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>commits@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/commits/archive</archive>
-        </mailingList>
-    </mailingLists>
 
     <issueManagement>
         <system>IssueTracker</system>
-        <url>http://java.net/jira/browse/GLASSFISH</url>
+        <url>https://github.com/javaee/repackaged/issues</url>
     </issueManagement>
 
     <build>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -50,7 +50,7 @@
     </parent>
     <groupId>org.glassfish.external</groupId>
     <artifactId>ant</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>1.10.1-SNAPSHOT</version>
     <name>Ant repackaged as an OSGI bundle</name>
 
     <properties>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -85,7 +85,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.0.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/antlr/pom.xml
+++ b/antlr/pom.xml
@@ -50,12 +50,12 @@
     </parent>
     <groupId>org.glassfish.external</groupId>
     <artifactId>antlr</artifactId>
-    <version>2.7.7-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     
     <name>Antlr, repackaged as an OSGI bundle</name>
     
     <properties>
-        <antlr.version>2.7.6</antlr.version>
+        <antlr.version>2.7.7</antlr.version>
         <release.arguments />
     </properties>
     
@@ -69,41 +69,14 @@
     </licenses>
     
     <scm>
-        <connection>scm:svn:https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/antlr</connection>
-        <developerConnection>scm:svn:https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/antlr</developerConnection>
-        <url>https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/antlr</url>
+        <connection>scm:git:git@github.com:javaee/repackaged.git</connection>
+        <developerConnection>scm:git:git@github.com:javaee/repackaged.git</developerConnection>
+        <url>https://github.com/javaee/repackaged.git</url>
     </scm>
-    
-    <mailingLists>
-        <mailingList>
-            <name>dev</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>dev@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/dev/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>users</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>users@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/users/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>issues</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>issues@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/issues/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>commits</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>commits@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/commits/archive</archive>
-        </mailingList>
-    </mailingLists>
-    
+       
     <issueManagement>
         <system>IssueTracker</system>
-        <url>http://java.net/jira/browse/GLASSFISH</url>
+        <url>https://github.com/javaee/repackaged/issues</url>
     </issueManagement>            
 
     <build>

--- a/antlr/pom.xml
+++ b/antlr/pom.xml
@@ -206,34 +206,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- 
-                unpack and attach the sources.jar available
-                This allows us to generate proper sources.jar and javadoc.jar
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-source-step1</id>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>antlr</groupId>
-                                    <artifactId>antlr</artifactId>
-                                    <version>${antlr.version}</version>
-                                    <classifier>sources</classifier>
-                                    <outputDirectory>${project.build.directory}/sources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>-->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/antlr/pom.xml
+++ b/antlr/pom.xml
@@ -50,7 +50,7 @@
     </parent>
     <groupId>org.glassfish.external</groupId>
     <artifactId>antlr</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>2.7.7-SNAPSHOT</version>
     
     <name>Antlr, repackaged as an OSGI bundle</name>
     

--- a/antlr/pom.xml
+++ b/antlr/pom.xml
@@ -56,6 +56,8 @@
     
     <properties>
         <antlr.version>2.7.7</antlr.version>
+        <antlr.source.url>http://www.antlr2.org/download/antlr-${antlr.version}.tar.gz</antlr.source.url>
+        <antlr.source.artifact>antlr-${antlr.version}</antlr.source.artifact>
         <release.arguments />
     </properties>
     
@@ -178,10 +180,36 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
+                Download the source distribution.
+            -->
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <target>
+                                <get src="${antlr.source.url}" dest="${project.build.directory}"/>
+                                <gunzip src="${project.build.directory}/${antlr.source.artifact}.tar.gz" dest="${project.build.directory}"/>
+                                <untar src="${project.build.directory}/${antlr.source.artifact}.tar" dest="${project.build.directory}/sources">
+                                    <patternset>
+                                        <include name="antlr"/>
+                                    </patternset>
+                                </untar>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- 
                 unpack and attach the sources.jar available
                 This allows us to generate proper sources.jar and javadoc.jar
-            -->
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -205,7 +233,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin>-->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
Update:

1. ant from 1.8.2 -> 1.10.1
2. antlr from 2.7.6 - > 2.7.7

Update the org.glassfish.external{ant,anlr} to 5.0-SNAPSHOT to align with the glassfish source. This way the artifacts can be released once per glassfish release and not for every build.

The maven-dependency-plugin needed to be removed as the antlr 2.7.7 sources jar are not published on maven and hence need to bundle them separately.