### PR TITLE
Trilead Update

### DIFF
--- a/trilead-ssh2/pom.xml
+++ b/trilead-ssh2/pom.xml
@@ -10,12 +10,12 @@
     and Distribution License("CDDL") (collectively, the "License").  You
     may not use this file except in compliance with the License.  You can
     obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
     language governing permissions and limitations under the License.
 
     When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
+    file and include the License file at LICENSE.txt.
 
     GPL Classpath Exception:
     Oracle designates this particular file as subject to the "Classpath"
@@ -45,8 +45,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>net.java</groupId>
-	<artifactId>jvnet-parent</artifactId>
-        <version>4</version>
+        <artifactId>jvnet-parent</artifactId>
+        <version>5</version>
     </parent>
     <groupId>org.glassfish.external</groupId>
     <artifactId>trilead-ssh2</artifactId>
@@ -55,7 +55,8 @@
     <name>trilead-ssh2 repackaged as an OSGI bundle</name>
     
     <properties>
-        <trilead-ssh2.version>build212-hudson-6</trilead-ssh2.version>
+        <trilead-ssh2.version>build-217-jenkins-11</trilead-ssh2.version>
+        <eddsa.version>0.2.0</eddsa.version>
         <release.arguments />
     </properties>
     
@@ -69,41 +70,14 @@
     </licenses>
     
     <scm>
-        <connection>scm:svn:https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/trilead-ssh2</connection>
-        <developerConnection>scm:svn:https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/trilead-ssh2</developerConnection>
-        <url>https://svn.java.net/svn/glassfish~svn/trunk/external/repackaged/trilead-ssh2</url>
+        <connection>scm:git:git@github.com:javaee/repackaged.git</connection>
+        <developerConnection>scm:git:git@github.com:javaee/repackaged.git</developerConnection>
+        <url>https://github.com/javaee/repackaged.git</url>
     </scm>
-    
-    <mailingLists>
-        <mailingList>
-            <name>dev</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>dev@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/dev/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>users</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>users@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/users/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>issues</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>issues@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/issues/archive</archive>
-        </mailingList>
-        <mailingList>
-            <name>commits</name>
-            <subscribe>http://java.net/projects/glassfish/lists</subscribe>
-            <post>commits@glassfish.java.net</post>
-            <archive>http://java.net/projects/glassfish/lists/commits/archive</archive>
-        </mailingList>
-    </mailingLists>
-    
+
     <issueManagement>
         <system>IssueTracker</system>
-        <url>http://java.net/jira/browse/GLASSFISH</url>
+        <url>https://github.com/javaee/repackaged/issues</url>
     </issueManagement>            
 
     <build>
@@ -112,7 +86,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.4</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -122,7 +96,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -214,7 +188,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.jvnet.hudson</groupId>
+                                    <groupId>org.jenkins-ci</groupId>
                                     <artifactId>trilead-ssh2</artifactId>
                                     <version>${trilead-ssh2.version}</version>
                                     <classifier>sources</classifier>
@@ -272,15 +246,44 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <arguments>${release.arguments}</arguments>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>1.9.4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
-    
+
+    <repositories>
+        <repository>
+            <id>Jenkins repo</id>
+            <url>http://repo.jenkins-ci.org/releases</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
-            <groupId>org.jvnet.hudson</groupId>
+            <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
             <optional>true</optional>
             <version>${trilead-ssh2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.i2p.crypto</groupId>
+            <artifactId>eddsa</artifactId>
+            <version>${eddsa.version}</version>
         </dependency>
     </dependencies>
 

--- a/trilead-ssh2/release.sh
+++ b/trilead-ssh2/release.sh
@@ -85,5 +85,5 @@ ARGS=" $*"
 # everything supplied as argument will be provided to every maven command.
 # e.g to supply -Dmaven.skip.test or -Dmaven.repo.local=/path/to/repo
 
-mvn -B -e release:prepare -DpreparationGoals="'install' $ARGS" $ARGS -Prelease
-mvn -B -e release:perform -Dgoals="'deploy' $ARGS" $ARGS -Prelease
+mvn -B -e release:prepare -DpreparationGoals="'install' $ARGS" $ARGS -Pjvnet-release,release
+mvn -B -e release:perform -Dgoals="'deploy' $ARGS" $ARGS -Pjvnet-release,release


### PR DESCRIPTION
- Update trilead from `build212-hudson-6` to `build-217-jenkins-11`
- Add  `net.i2p.crypto:eddsa:0.2.0` dependency which would be bundled during repackaging 